### PR TITLE
Install parent-theme-2021, which is required by translation events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,5 @@ tmp/po/*.po
 glotpress.git
 meta-environment-vvv.git
 meta.git
+wporg-parent-2021.git
 wporg-mu-plugins.git

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -18,6 +18,7 @@
 		"WPORGPATH": "/var/www/html/wp-content/themes/pub/wporg/inc/",
 		"GP_URL_BASE":  "/",
 		"GP_TMPL_PATH": "/var/www/html/wp-content/plugins/wporg-gp-customizations/templates/",
-		"FEATURE_2021_GLOBAL_HEADER_FOOTER": false
+		"FEATURE_2021_GLOBAL_HEADER_FOOTER": false,
+		"TRANSLATION_EVENTS_NEW_DESIGN": true
 	}
 }

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -6,6 +6,7 @@
 		"wp-content": "./meta.git/wordpress.org/public_html/wp-content",
 		"wp-content/plugins/glotpress": "./glotpress.git",
 		"wp-content/themes/pub": "./meta.git/wordpress.org/public_html/wp-content/themes/pub/wporg",
+		"wp-content/themes/wporg-parent-2021": "./wporg-parent-2021.git/source/wp-content/themes/wporg-parent-2021",
 		"wp-content/mu-plugins/pub-sync": "./wporg-mu-plugins.git/mu-plugins",
 		"wp-content/mu-plugins/_loader.php": "./tmp/_loader.php",
 		"tmp": "./tmp",

--- a/provision.sh
+++ b/provision.sh
@@ -249,7 +249,7 @@ fi
 # Enable the rosetta theme
 # To see the available themes, execute: npm run wp-env run cli wp theme list
 print_header "Enabling the wporg theme"
-$WP_CLI_PREFIX wp theme activate pub $WP_CLI_SUFFIX
+$WP_CLI_PREFIX wp theme activate pub/wporg $WP_CLI_SUFFIX
 print_header "Importing the translation tables"
 $WP_CLI_PREFIX wp db import tmp/translate_tables.sql $WP_CLI_SUFFIX
 # Remove this table, because the old dump hasn't some fields

--- a/provision.sh
+++ b/provision.sh
@@ -120,6 +120,7 @@ function clone_repos() {
   git checkout develop
   cd -
   echo "${GREEN}GlotPress repo cloned and/or updated.${RESET}"
+
   echo "${YELLOW}Cloning and/or pulling meta repo.${RESET}"
   [[ -d meta.git ]] || git clone https://github.com/wordpress/wordpress.org meta.git
   cd meta.git
@@ -128,7 +129,18 @@ function clone_repos() {
   git checkout trunk
   cd -
   echo "${GREEN}Meta repo cloned and/or updated.${RESET}"
-  echo "${YELLOW}Cloning and/or pulling meta repo.${RESET}"
+
+  echo "${YELLOW}Cloning and/or pulling wporg-parent-2021 repo.${RESET}"
+  [[ -d wporg-parent-2021.git ]] || git clone https://github.com/wordpress/wporg-parent-2021 wporg-parent-2021.git
+  cd wporg-parent-2021.git
+  git config pull.ff only
+  git pull
+  yarn setup:tools
+  yarn workspaces run build
+  cd -
+  echo "${GREEN}WordPress.org wporg-parent-2021 repo cloned and/or updated.${RESET}"
+
+  echo "${YELLOW}Cloning and/or pulling wporg-mu-plugins repo.${RESET}"
   [[ -d wporg-mu-plugins.git ]] || git clone https://github.com/wordpress/wporg-mu-plugins wporg-mu-plugins.git
   cd wporg-mu-plugins.git
   git config pull.ff only
@@ -136,8 +148,8 @@ function clone_repos() {
   git checkout trunk
   npm install
   npm run build
-  echo "${GREEN}WordPress.org mu-plugins repo cloned and/or updated.${RESET}"
   cd -
+  echo "${GREEN}WordPress.org mu-plugins repo cloned and/or updated.${RESET}"
 }
 
 function copy_repos() {
@@ -157,6 +169,7 @@ function copy_repos() {
   ln -s `pwd`/meta.git/wordpress.org/public_html/wp-content/themes $project_path/wp-content/themes
   ln -s `pwd`/glotpress.git/ $project_path/wp-content/plugins/glotpress
   ln -s `pwd`/meta.git/wordpress.org/public_html/wp-content/themes/pub/wporg $project_path/wp-content/themes/pub/
+  ln -s `pwd`/wporg-parent-2021.git/source/wp-content/themes/wporg-parent-2021 $project_path/wp-content/themes/
   cp ./.wp-env/.htaccess $project_path/
   echo "${GREEN}Items copied.${RESET}"
 }

--- a/scripts/pull_repos.sh
+++ b/scripts/pull_repos.sh
@@ -8,6 +8,7 @@ function print_header() {
   echo ''
 }
 print_header "Cloning and/or pulling GlotPress and WordPress.org"
+
 # Get a copy from GlotPress and Meta only if the folder doesn't exist
 # Pull the repo looking for updates
 [[ -d glotpress.git ]] || git clone https://github.com/GlotPress/GlotPress-WP.git glotpress.git
@@ -15,11 +16,21 @@ cd glotpress.git
 git config pull.ff only
 git pull
 cd -
+
 [[ -d meta.git ]] || git clone https://github.com/wordpress/wordpress.org meta.git
 cd meta.git
 git config pull.ff only
 git pull
 cd -
+
+[[ -d wporg-parent-2021.git ]] || git clone https://github.com/wordpress/wporg-parent-2021 wporg-parent-2021.git
+cd wporg-parent-2021.git
+git config pull.ff only
+git pull
+yarn setup:tools
+yarn workspaces run build
+cd -
+
 # todo: remove the wporg-mu-plugins.git clone and the other commands when we have the first beta version
 [[ -d wporg-mu-plugins.git ]] || git clone https://github.com/WordPress/wporg-mu-plugins wporg-mu-plugins.git
 cd wporg-mu-plugins.git


### PR DESCRIPTION
This PR makes it so that the `pull_repos.sh` script also pulls the [wporg-parent-2021 ](https://github.com/WordPress/wporg-parent-2021) theme, and the `provision.sh` script links in under `wp-content/themes`. 

This theme is required by translation events. It is already present on the production environment.